### PR TITLE
Remove unneeded vars.pm, POSIX.pm, and string eval.

### DIFF
--- a/lib/SVG/TT/Graph.pm
+++ b/lib/SVG/TT/Graph.pm
@@ -2,14 +2,13 @@ package SVG::TT::Graph;
 
 use strict;
 use Carp;
-
-use vars qw($VERSION $AUTOLOAD $TEMPLATE_FH);
 use Template;
-use POSIX;
 
 require 5.6.1;
 
-$VERSION = '0.24';
+our $VERSION = '0.24';
+our $AUTOLOAD;
+our $TEMPLATE_FH;
 
 =head1 NAME
 
@@ -20,9 +19,8 @@ SVG::TT::Graph - Base module for generating SVG graphics
   package SVG::TT::Graph::GRAPH_TYPE;
   use SVG::TT::Graph;
   use base qw(SVG::TT::Graph);
-  use vars qw($VERSION);
-  $VERSION = $SVG::TT::Graph::VERSION;
-  $TEMPLATE_FH = \*DATA;
+  our $VERSION = $SVG::TT::Graph::VERSION;
+  our $TEMPLATE_FH = \*DATA;
 
   sub _set_defaults {
     my $self = shift;
@@ -214,9 +212,10 @@ sub get_template {
   my $self = shift;
 
   # Template filehandle
-  my $class = ref($self);
-  my $template_fh = eval('$'.$class.'::TEMPLATE_FH');
-  croak $class . ' must have a template' if not $template_fh;
+  my $template_fh_sr = $self->_get_template_fh_sr();
+  croak ref($self) . ' must have a template' if not $template_fh_sr;
+
+  my $template_fh = $$template_fh_sr;
 
   # Read in TT template
   my $start = tell $template_fh;
@@ -230,6 +229,17 @@ sub get_template {
   seek $template_fh, $start, 0;
 
   return $template;
+}
+
+sub _get_template_fh_sr {
+    my ($self) = @_;
+
+    my $ns_ref = \%main::;
+    for my $node ( split m<::>, ref $self ) {
+        $ns_ref = $ns_ref->{"${node}::"};
+    }
+
+    return *{$ns_ref->{'TEMPLATE_FH'}}{'SCALAR'};
 }
 
 =head2 burn()

--- a/lib/SVG/TT/Graph/Bar.pm
+++ b/lib/SVG/TT/Graph/Bar.pm
@@ -4,9 +4,9 @@ use strict;
 use Carp;
 use SVG::TT::Graph;
 use base qw(SVG::TT::Graph);
-use vars qw($VERSION $TEMPLATE_FH);
-$VERSION = $SVG::TT::Graph::VERSION;
-$TEMPLATE_FH = \*DATA;
+
+our $VERSION = $SVG::TT::Graph::VERSION;
+our $TEMPLATE_FH = \*DATA;
 
 =head1 NAME
 

--- a/lib/SVG/TT/Graph/BarHorizontal.pm
+++ b/lib/SVG/TT/Graph/BarHorizontal.pm
@@ -4,9 +4,9 @@ use strict;
 use Carp;
 use SVG::TT::Graph;
 use base qw(SVG::TT::Graph);
-use vars qw($VERSION $TEMPLATE_FH);
-$VERSION = $SVG::TT::Graph::VERSION;
-$TEMPLATE_FH = \*DATA;
+
+our $VERSION = $SVG::TT::Graph::VERSION;
+our $TEMPLATE_FH = \*DATA;
 
 =head1 NAME
 

--- a/lib/SVG/TT/Graph/BarLine.pm
+++ b/lib/SVG/TT/Graph/BarLine.pm
@@ -4,9 +4,9 @@ use strict;
 use Carp;
 use SVG::TT::Graph;
 use base qw(SVG::TT::Graph);
-use vars qw($VERSION $TEMPLATE_FH);
-$VERSION = $SVG::TT::Graph::VERSION;
-$TEMPLATE_FH = \*DATA;
+
+our $VERSION = $SVG::TT::Graph::VERSION;
+our $TEMPLATE_FH = \*DATA;
 
 =head1 NAME
 

--- a/lib/SVG/TT/Graph/Bubble.pm
+++ b/lib/SVG/TT/Graph/Bubble.pm
@@ -4,9 +4,9 @@ use strict;
 use Carp;
 use SVG::TT::Graph;
 use base qw(SVG::TT::Graph);
-use vars qw($VERSION $TEMPLATE_FH);
-$VERSION     = $SVG::TT::Graph::VERSION;
-$TEMPLATE_FH = \*DATA;
+
+our $VERSION     = $SVG::TT::Graph::VERSION;
+our $TEMPLATE_FH = \*DATA;
 
 
 =head1 NAME

--- a/lib/SVG/TT/Graph/Line.pm
+++ b/lib/SVG/TT/Graph/Line.pm
@@ -4,9 +4,9 @@ use strict;
 use Carp;
 use SVG::TT::Graph;
 use base qw(SVG::TT::Graph);
-use vars qw($VERSION $TEMPLATE_FH);
-$VERSION = $SVG::TT::Graph::VERSION;
-$TEMPLATE_FH = \*DATA;
+
+our $VERSION = $SVG::TT::Graph::VERSION;
+our $TEMPLATE_FH = \*DATA;
 
 =head1 NAME
 

--- a/lib/SVG/TT/Graph/Pie.pm
+++ b/lib/SVG/TT/Graph/Pie.pm
@@ -4,9 +4,9 @@ use strict;
 use Carp;
 use SVG::TT::Graph;
 use base qw(SVG::TT::Graph);
-use vars qw($VERSION $TEMPLATE_FH);
-$VERSION = $SVG::TT::Graph::VERSION;
-$TEMPLATE_FH = \*DATA;
+
+our $VERSION = $SVG::TT::Graph::VERSION;
+our $TEMPLATE_FH = \*DATA;
 
 =head1 NAME
 

--- a/lib/SVG/TT/Graph/TimeSeries.pm
+++ b/lib/SVG/TT/Graph/TimeSeries.pm
@@ -4,9 +4,9 @@ use strict;
 use Carp;
 use SVG::TT::Graph;
 use base qw(SVG::TT::Graph);
-use vars qw($VERSION $TEMPLATE_FH);
-$VERSION = $SVG::TT::Graph::VERSION;
-$TEMPLATE_FH = \*DATA;
+
+our $VERSION = $SVG::TT::Graph::VERSION;
+our $TEMPLATE_FH = \*DATA;
 
 use Data::Dumper;
 use HTTP::Date;

--- a/lib/SVG/TT/Graph/XY.pm
+++ b/lib/SVG/TT/Graph/XY.pm
@@ -4,9 +4,9 @@ use strict;
 use Carp;
 use SVG::TT::Graph;
 use base qw(SVG::TT::Graph);
-use vars qw($VERSION $TEMPLATE_FH);
-$VERSION = $SVG::TT::Graph::VERSION;
-$TEMPLATE_FH = \*DATA;
+
+our $VERSION = $SVG::TT::Graph::VERSION;
+our $TEMPLATE_FH = \*DATA;
 
 
 =head1 NAME


### PR DESCRIPTION
Since Perl 5.6 is required, vars.pm shouldn’t be needed.
POSIX.pm isn’t used in the base class.
The string eval can be replaced with a lookup via the symbol table.

I can split these up if you prefer, but they seem pretty safe changes. I do not have Perl 5.6, and 5.8 on my machine couldn’t install List::MoreUtils, but 5.10 passed, as did my box’s native 5.16.