### PR TITLE
 Added back POSIX to SVG/TT/Graph.pm

### DIFF
--- a/lib/SVG/TT/Graph.pm
+++ b/lib/SVG/TT/Graph.pm
@@ -3,7 +3,7 @@ package SVG::TT::Graph;
 use strict;
 use Carp;
 use Template;
-
+use POSIX;
 require 5.6.1;
 
 our $VERSION = '0.26';


### PR DESCRIPTION
The Ceil subroutine  from POSIX is used by SVG::TT::Graph::_range_calc.