### PR TITLE
Add ability to specify inline CSS directly and not require external style sheet.

### DIFF
--- a/lib/SVG/TT/Graph/Pie.pm
+++ b/lib/SVG/TT/Graph/Pie.pm
@@ -163,6 +163,9 @@ Whether or not to tidy the content of the SVG file (XML::Tidy required).
 Set the path to an external stylesheet, set to '' if
 you want to revert back to using the defaut internal version.
 
+Set to "inline:<style>...</style>" with your CSS in between the tags.
+You can thus override the default style without requireing an external URL. 
+
 The default stylesheet handles up to 12 data sets. All data series over
 the 12th will have no style and be in black. If you have over 12 data
 sets you can assign them all random colors (see the random_color()

--- a/lib/SVG/TT/Graph/Pie.pm
+++ b/lib/SVG/TT/Graph/Pie.pm
@@ -380,8 +380,11 @@ __DATA__
   "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
 [% stylesheet = 'included' %]
 
-[% IF config.style_sheet && config.style_sheet != '' %]
+[% IF config.style_sheet && config.style_sheet != '' && config.style_sheet.substr(0,7) != 'inline:' %]
   <?xml-stylesheet href="[% config.style_sheet %]" type="text/css"?>
+[% ELSIF config.style_sheet && config.style_sheet.substr(0,7) == 'inline:'%]
+  [% stylesheet = 'inline' 
+     style_inline = config.style_sheet.substr(7) %]
 [% ELSE %]
   [% stylesheet = 'excluded' %]
 [% END %]
@@ -398,7 +401,9 @@ __DATA__
     <stop offset="100%" style="stop-color: #ccc;stop-opacity: 0"/>
   </radialGradient>
 
-[% IF stylesheet == 'excluded' %]
+[% IF stylesheet == 'inline' %]
+[% style_inline %]
+[% ELSIF stylesheet == 'excluded' %]
 <!-- include default stylesheet if none specified -->
 <style type="text/css">
 <![CDATA[


### PR DESCRIPTION
I needed to be able to change the CSS for a given graph in the code used to generate it.  I amended the 'style_sheet' option.  If it starts with "inline:', the rest of the string is assumed to be a style block complete with the <style> and </style> tags. This allows a user to override the default without having to create an external file.