### PR TITLE
Call tzset conditionally

### DIFF
--- a/lib/SVG/TT/Graph/TimeSeries.pm
+++ b/lib/SVG/TT/Graph/TimeSeries.pm
@@ -579,7 +579,7 @@ sub calculations {
   # Need to set the timezone in order for x-axis labels to be 
   # formatted correctly by strftime:
   $ENV{'TZ'} = $self->{config}->{timescale_time_zone};
-  POSIX::tzset();
+  POSIX::tzset() if ($] lt '5008009');
 
   # run through the data and calculate maximum and minimum values
   my ($max_key_size,$max_time,$min_time,$max_value,$min_value,$max_x_label_length,$x_label);


### PR DESCRIPTION
Hi, thank you for your work on this module.

`POSIX::tzset` is called once within TimeSeries.pm, I don't think this is required as of perl version 5.8.9, and Strawberry Perl no longer ships with support for this. I've added an if condition only to call tzset if the perl version is lower than 5.8.9.

References: https://rt.cpan.org/Ticket/Display.html?id=131606

Thanks